### PR TITLE
Initial project skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables
+HF_TOKEN=
+MODEL_SIZE=small
+DATABASE_URL=sqlite:///./db.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+/db.sqlite3
+/app/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT=7210
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7210"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, Request, UploadFile, File, BackgroundTasks
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.orm import sessionmaker, declarative_base
+from datetime import datetime
+import shutil
+import os
+
+from .transcribe import transcribe_file
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db.sqlite3")
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+class Transcript(Base):
+    __tablename__ = "transcripts"
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, nullable=False)
+    status = Column(String, default="pending")
+    result = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")), name="static")
+
+templates = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), "templates"))
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    db = SessionLocal()
+    files = db.query(Transcript).order_by(Transcript.created_at.desc()).all()
+    db.close()
+    return templates.TemplateResponse("index.html", {"request": request, "files": files})
+
+@app.post("/upload", response_class=HTMLResponse)
+def upload_file(request: Request, background_tasks: BackgroundTasks, file: UploadFile = File(...)):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    db = SessionLocal()
+    file_path = os.path.join(UPLOAD_DIR, file.filename)
+    with open(file_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    record = Transcript(filename=file.filename)
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    background_tasks.add_task(transcribe_file, record.id, file_path)
+    db.close()
+    return templates.TemplateResponse("upload_success.html", {"request": request, "filename": file.filename})

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,3 @@
+body {
+    background-color: #f8f9fa;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>4Ears</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+    <h1>Upload Audio/Video</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data" class="mb-3">
+        <input class="form-control" type="file" name="file" accept="audio/*,video/*" required>
+        <button class="btn btn-primary mt-2" type="submit">Upload & Transcribe</button>
+    </form>
+    <h2>Past Transcripts</h2>
+    <table class="table table-striped">
+        <thead>
+            <tr><th>File</th><th>Status</th><th>Result</th><th>Created</th></tr>
+        </thead>
+        <tbody>
+        {% for f in files %}
+            <tr>
+                <td>{{ f.filename }}</td>
+                <td>{{ f.status }}</td>
+                <td>{{ f.result or '' }}</td>
+                <td>{{ f.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/app/templates/upload_success.html
+++ b/app/templates/upload_success.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Uploaded</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+    <h1>File {{ filename }} uploaded!</h1>
+    <p>Transcription will start shortly.</p>
+    <a class="btn btn-link" href="/">Back to list</a>
+</body>
+</html>

--- a/app/transcribe.py
+++ b/app/transcribe.py
@@ -1,0 +1,25 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import os
+import time
+
+from .main import Base, Transcript, DATABASE_URL
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine)
+
+
+def transcribe_file(record_id: int, file_path: str):
+    db = SessionLocal()
+    record = db.query(Transcript).get(record_id)
+    if not record:
+        db.close()
+        return
+    record.status = "processing"
+    db.commit()
+    # Placeholder transcription logic
+    time.sleep(2)  # simulate work
+    record.status = "completed"
+    record.result = f"Transcribed text for {os.path.basename(file_path)}"
+    db.commit()
+    db.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+      - "7210:7210"
+    volumes:
+      - ./app/data:/app/app/data
+      - ./db.sqlite3:/app/db.sqlite3
+    env_file:
+      - .env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy
+jinja2


### PR DESCRIPTION
## Summary
- scaffold FastAPI app with Jinja2 templates
- add placeholder transcription logic
- support uploads and history via SQLite
- provide Dockerfile and docker-compose for easy startup

## Testing
- `python3 -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685fd9c6cda883218a3a5b944912c97b