### PR TITLE
Fix circular import by splitting DB layer

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,24 @@
+import os
+from datetime import datetime
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db.sqlite3")
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+class Transcript(Base):
+    __tablename__ = "transcripts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, nullable=False)
+    status = Column(String, default="pending")
+    result = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+Base.metadata.create_all(bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -2,29 +2,12 @@ from fastapi import FastAPI, Request, UploadFile, File, BackgroundTasks
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
-from sqlalchemy import create_engine, Column, Integer, String, DateTime
-from sqlalchemy.orm import sessionmaker, declarative_base
-from datetime import datetime
+from .db import SessionLocal, Transcript
 import shutil
 import os
 
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db.sqlite3")
 UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "data")
-
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
-SessionLocal = sessionmaker(bind=engine)
-Base = declarative_base()
-
-class Transcript(Base):
-    __tablename__ = "transcripts"
-    id = Column(Integer, primary_key=True, index=True)
-    filename = Column(String, nullable=False)
-    status = Column(String, default="pending")
-    result = Column(String, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-
-Base.metadata.create_all(bind=engine)
 
 from .transcribe import transcribe_file
 

--- a/app/transcribe.py
+++ b/app/transcribe.py
@@ -3,18 +3,12 @@ import logging
 import tempfile
 import shutil
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 from pydub import AudioSegment
 import whisperx
 
-from .main import Transcript, DATABASE_URL
+from .db import Transcript, DATABASE_URL, SessionLocal
 
 logger = logging.getLogger(__name__)
-
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
-SessionLocal = sessionmaker(bind=engine)
-
 
 def _convert_to_wav(path: str, temp_dir: str) -> str:
     """Convert input audio to wav if necessary and return new path."""


### PR DESCRIPTION
## Summary
- isolate database models in a new `db.py`
- update `main.py` and `transcribe.py` to use the shared DB module

## Testing
- `python -m py_compile app/main.py app/transcribe.py app/db.py`
- `docker-compose` not available in environment

------
https://chatgpt.com/codex/tasks/task_e_685fe0c774d48321955ba6072ad3b246