### PR TITLE
Add simple login system with token settings

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -20,5 +20,14 @@ class Transcript(Base):
     result = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    hf_token = Column(String, nullable=True)
+    openai_token = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
 
 Base.metadata.create_all(bind=engine)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,6 +6,15 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body class="container py-4">
+    <nav class="mb-3">
+        {% if user %}
+            <span class="me-2">Logged in as {{ user.username }}</span>
+            <a class="btn btn-sm btn-secondary" href="/settings">Tokens</a>
+            <a class="btn btn-sm btn-link" href="/logout">Logout</a>
+        {% else %}
+            <a class="btn btn-sm btn-primary" href="/login">Login</a>
+        {% endif %}
+    </nav>
     <h1>Upload Audio/Video</h1>
     <form action="/upload" method="post" enctype="multipart/form-data" class="mb-3">
         <input class="form-control" type="file" name="file" accept="audio/*,video/*" required>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+    <h1>Login</h1>
+    {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+    <form method="post">
+        <div class="mb-3">
+            <input class="form-control" type="text" name="username" placeholder="Username" required>
+        </div>
+        <div class="mb-3">
+            <input class="form-control" type="password" name="password" placeholder="Password" required>
+        </div>
+        <button class="btn btn-primary" type="submit">Login</button>
+    </form>
+    <p class="mt-3"><a href="/register">Register</a></p>
+</body>
+</html>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Register</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+    <h1>Register</h1>
+    {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+    <form method="post">
+        <div class="mb-3">
+            <input class="form-control" type="text" name="username" placeholder="Username" required>
+        </div>
+        <div class="mb-3">
+            <input class="form-control" type="password" name="password" placeholder="Password" required>
+        </div>
+        <button class="btn btn-primary" type="submit">Register</button>
+    </form>
+    <p class="mt-3"><a href="/login">Login</a></p>
+</body>
+</html>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>API Tokens</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+    <h1>API Tokens</h1>
+    {% if success %}<div class="alert alert-success">Saved</div>{% endif %}
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label">HuggingFace Token</label>
+            <input class="form-control" type="text" name="hf_token" value="{{ user.hf_token or '' }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">OpenAI Token</label>
+            <input class="form-control" type="text" name="openai_token" value="{{ user.openai_token or '' }}">
+        </div>
+        <button class="btn btn-primary" type="submit">Save</button>
+    </form>
+    <p class="mt-3"><a href="/">Home</a></p>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ sqlalchemy
 jinja2
 whisperx
 pydub
+
+passlib[bcrypt]
+python-multipart


### PR DESCRIPTION
## Summary
- add a `User` model for authentication
- implement session-based login/logout and registration
- provide a settings page for saving HuggingFace/OpenAI tokens
- update main page to show login status
- add dependencies for password hashing and form handling

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686529c99fb08321b7ffa46a33d6c0ef