### PR TITLE
Fix missing dependency for session middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydub
 
 passlib[bcrypt]
 python-multipart
+itsdangerous


### PR DESCRIPTION
## Summary
- install `itsdangerous` for session management

## Testing
- `docker-compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686530d675988321afde888b694fd117