### PR TITLE
Add progress polling and dark mode

### DIFF
--- a/app/static/dark.js
+++ b/app/static/dark.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const body = document.getElementById('body');
+  const toggle = document.getElementById('dark-toggle');
+  const prefersDark = localStorage.getItem('darkMode') !== '0';
+  if (prefersDark) {
+    body.classList.add('dark');
+  }
+  toggle.innerText = body.classList.contains('dark') ? 'Light Mode' : 'Dark Mode';
+  toggle.addEventListener('click', () => {
+    body.classList.toggle('dark');
+    const dark = body.classList.contains('dark');
+    localStorage.setItem('darkMode', dark ? '1' : '0');
+    toggle.innerText = dark ? 'Light Mode' : 'Dark Mode';
+  });
+});

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,3 +1,23 @@
+:root {
+    --bg-light: #f8f9fa;
+    --bg-dark: #121212;
+    --text-light: #212529;
+    --text-dark: #f8f9fa;
+}
+
 body {
-    background-color: #f8f9fa;
+    background-color: var(--bg-light);
+    color: var(--text-light);
+}
+
+body.dark {
+    background-color: var(--bg-dark);
+    color: var(--text-dark);
+}
+
+.result-snippet {
+    max-width: 400px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,8 +4,9 @@
     <title>4Ears</title>
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <script src="/static/dark.js"></script>
 </head>
-<body class="container py-4">
+<body class="container py-4" id="body">
     <nav class="mb-3">
         {% if user %}
             <span class="me-2">Logged in as {{ user.username }}</span>
@@ -14,6 +15,7 @@
         {% else %}
             <a class="btn btn-sm btn-primary" href="/login">Login</a>
         {% endif %}
+        <button id="dark-toggle" type="button" class="btn btn-sm btn-secondary ms-2"></button>
     </nav>
     <h1>Upload Audio/Video</h1>
     <form action="/upload" method="post" enctype="multipart/form-data" class="mb-3">
@@ -30,7 +32,12 @@
             <tr>
                 <td>{{ f.filename }}</td>
                 <td>{{ f.status }}</td>
-                <td>{{ f.result or '' }}</td>
+                <td>
+                    {% if f.result %}
+                        <span class="result-snippet">{{ f.result[:150] }}{% if f.result|length > 150 %}...{% endif %}</span>
+                        <a class="btn btn-sm btn-secondary ms-2" href="/download/{{ f.id }}">Download</a>
+                    {% endif %}
+                </td>
                 <td>{{ f.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
             </tr>
         {% endfor %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -4,8 +4,9 @@
     <title>Login</title>
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <script src="/static/dark.js"></script>
 </head>
-<body class="container py-4">
+<body class="container py-4" id="body">
     <h1>Login</h1>
     {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
     <form method="post">
@@ -18,5 +19,6 @@
         <button class="btn btn-primary" type="submit">Login</button>
     </form>
     <p class="mt-3"><a href="/register">Register</a></p>
+    <button id="dark-toggle" type="button" class="btn btn-sm btn-secondary mt-3"></button>
 </body>
 </html>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -4,8 +4,9 @@
     <title>Register</title>
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <script src="/static/dark.js"></script>
 </head>
-<body class="container py-4">
+<body class="container py-4" id="body">
     <h1>Register</h1>
     {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
     <form method="post">
@@ -18,5 +19,6 @@
         <button class="btn btn-primary" type="submit">Register</button>
     </form>
     <p class="mt-3"><a href="/login">Login</a></p>
+    <button id="dark-toggle" type="button" class="btn btn-sm btn-secondary mt-3"></button>
 </body>
 </html>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -4,8 +4,9 @@
     <title>API Tokens</title>
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <script src="/static/dark.js"></script>
 </head>
-<body class="container py-4">
+<body class="container py-4" id="body">
     <h1>API Tokens</h1>
     {% if success %}<div class="alert alert-success">Saved</div>{% endif %}
     <form method="post">
@@ -20,5 +21,6 @@
         <button class="btn btn-primary" type="submit">Save</button>
     </form>
     <p class="mt-3"><a href="/">Home</a></p>
+    <button id="dark-toggle" type="button" class="btn btn-sm btn-secondary mt-3"></button>
 </body>
 </html>

--- a/app/templates/upload_success.html
+++ b/app/templates/upload_success.html
@@ -4,10 +4,38 @@
     <title>Uploaded</title>
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <script src="/static/dark.js"></script>
 </head>
-<body class="container py-4">
+<body class="container py-4" id="body">
     <h1>File {{ filename }} uploaded!</h1>
     <p>Transcription will start shortly.</p>
+    <div class="progress mb-3">
+        <div id="progress" class="progress-bar" role="progressbar" style="width:0%">Pending</div>
+    </div>
     <a class="btn btn-link" href="/">Back to list</a>
+    <button id="dark-toggle" type="button" class="btn btn-sm btn-secondary ms-2"></button>
+    <script>
+        const fileId = {{ file_id }};
+        function checkStatus() {
+            fetch(`/status/${fileId}`).then(r=>r.json()).then(data=>{
+                const bar = document.getElementById('progress');
+                if (data.status === 'completed') {
+                    bar.style.width = '100%';
+                    bar.innerText = 'Completed';
+                    clearInterval(intv);
+                } else if (data.status === 'processing') {
+                    bar.style.width = '50%';
+                    bar.innerText = 'Processing';
+                } else if (data.status === 'failed') {
+                    bar.classList.add('bg-danger');
+                    bar.style.width = '100%';
+                    bar.innerText = 'Failed';
+                    clearInterval(intv);
+                }
+            });
+        }
+        const intv = setInterval(checkStatus, 2000);
+        checkStatus();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dark mode script and styles
- update templates to support dark mode toggle
- show progress while transcription runs
- allow downloading transcript text
- truncate long transcription results in the list

## Testing
- `python -m py_compile app/main.py app/transcribe.py app/db.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68664a3a03408321ae5fe4bcb75d5662