### PR TITLE
Support per-user tokens for transcripts

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -27,6 +27,8 @@ def _ensure_schema() -> None:
                 )
             if "summary_mode" not in columns:
                 conn.execute(text("ALTER TABLE transcripts ADD COLUMN summary_mode TEXT"))
+            if "user_id" not in columns:
+                conn.execute(text("ALTER TABLE transcripts ADD COLUMN user_id INTEGER"))
 
 class Transcript(Base):
     __tablename__ = "transcripts"
@@ -38,6 +40,7 @@ class Transcript(Base):
     summary = Column(String, nullable=True)
     summary_status = Column(String, default="pending")
     summary_mode = Column(String, nullable=True)
+    user_id = Column(Integer, nullable=True, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
 class User(Base):

--- a/app/summarize.py
+++ b/app/summarize.py
@@ -3,15 +3,15 @@ import requests
 import openai
 
 
-def summarize(text: str, mode: str = "basic_summary") -> str:
+def summarize(text: str, mode: str = "basic_summary", openai_api_key: str | None = None) -> str:
     engine = os.getenv("SUMMARIZATION_ENGINE", "openai")
     if engine == "openai":
-        return summarize_openai(text, mode)
+        return summarize_openai(text, mode, openai_api_key)
     return summarize_ollama(text, mode)
 
 
-def summarize_openai(text: str, mode: str) -> str:
-    api_key = os.getenv("OPENAI_API_KEY")
+def summarize_openai(text: str, mode: str, api_key: str | None = None) -> str:
+    api_key = api_key or os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not configured")
     client = openai.OpenAI(api_key=api_key)


### PR DESCRIPTION
## Summary
- add `user_id` field to transcripts
- store the logged-in user on upload
- use per-user HuggingFace and OpenAI tokens during jobs
- allow passing OpenAI API key to summarizer
- show only the current user's transcripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866705a18a08321b714505d68ba2980