### PR TITLE
Use modern SQLAlchemy get API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ def get_current_user(request: Request):
     if not user_id:
         return None
     db = SessionLocal()
-    user = db.query(User).get(user_id)
+    user = db.get(User, user_id)
     db.close()
     return user
 
@@ -112,7 +112,7 @@ def settings_save(request: Request, hf_token: str = Form(""), openai_token: str 
     if not user:
         return RedirectResponse("/login", status_code=302)
     db = SessionLocal()
-    db_user = db.query(User).get(user.id)
+    db_user = db.get(User, user.id)
     db_user.hf_token = hf_token
     db_user.openai_token = openai_token
     db.commit()
@@ -124,7 +124,7 @@ def settings_save(request: Request, hf_token: str = Form(""), openai_token: str 
 @app.get("/status/{file_id}")
 def status(file_id: int):
     db = SessionLocal()
-    record = db.query(Transcript).get(file_id)
+    record = db.get(Transcript, file_id)
     if not record:
         db.close()
         return {"status": "unknown"}
@@ -136,7 +136,7 @@ def status(file_id: int):
 @app.get("/download/{file_id}")
 def download_text(file_id: int):
     db = SessionLocal()
-    record = db.query(Transcript).get(file_id)
+    record = db.get(Transcript, file_id)
     if not record or not record.result:
         db.close()
         return RedirectResponse("/", status_code=302)
@@ -149,7 +149,7 @@ def download_text(file_id: int):
 @app.post("/summarize/{file_id}")
 def summarize(file_id: int, background_tasks: BackgroundTasks, mode: str = Form("basic_summary")):
     db = SessionLocal()
-    record = db.query(Transcript).get(file_id)
+    record = db.get(Transcript, file_id)
     if not record or not record.result:
         db.close()
         return RedirectResponse("/", status_code=302)

--- a/app/transcribe.py
+++ b/app/transcribe.py
@@ -61,7 +61,7 @@ def _run_whisperx(wav_path: str, hf_token: str | None = None) -> str:
 
 def transcribe_file(record_id: int, file_path: str) -> None:
     db = SessionLocal()
-    record = db.query(Transcript).get(record_id)
+    record = db.get(Transcript, record_id)
     if not record:
         db.close()
         return
@@ -72,7 +72,7 @@ def transcribe_file(record_id: int, file_path: str) -> None:
     temp_dir = tempfile.mkdtemp(prefix="transcribe_")
     try:
         wav_path = _convert_to_wav(file_path, temp_dir)
-        user = db.query(User).get(record.user_id) if record.user_id else None
+        user = db.get(User, record.user_id) if record.user_id else None
         hf_token = (
             user.hf_token if user and user.hf_token else os.getenv("HF_TOKEN", "")
         )
@@ -92,7 +92,7 @@ def transcribe_file(record_id: int, file_path: str) -> None:
 
 def summarize_record(record_id: int, mode: str) -> None:
     db = SessionLocal()
-    record = db.query(Transcript).get(record_id)
+    record = db.get(Transcript, record_id)
     if not record or not record.result:
         db.close()
         return
@@ -103,7 +103,7 @@ def summarize_record(record_id: int, mode: str) -> None:
 
     try:
         text = record.result
-        user = db.query(User).get(record.user_id) if record.user_id else None
+        user = db.get(User, record.user_id) if record.user_id else None
         openai_token = (
             user.openai_token if user and user.openai_token else os.getenv("OPENAI_API_KEY")
         )


### PR DESCRIPTION
## Summary
- replace deprecated `db.query(...).get()` calls with `db.get()`

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo "py_compile OK"`


------
https://chatgpt.com/codex/tasks/task_e_68668158810c8321862505cc4a26aa38