### PR TITLE
Fix upload/table layout width mismatch

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -15,6 +15,11 @@ body.dark {
     color: var(--text-dark);
 }
 
+.main-content {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
 .result-snippet {
     max-width: 400px;
     overflow: hidden;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,6 +17,7 @@
         {% endif %}
         <button id="dark-toggle" type="button" class="btn btn-sm btn-secondary ms-2"></button>
     </nav>
+    <div class="main-content">
     <h1>Upload Audio/Video</h1>
     <form action="/upload" method="post" enctype="multipart/form-data" class="mb-3">
         <input class="form-control" type="file" name="file" accept="audio/*,video/*" required>
@@ -58,5 +59,6 @@
         {% endfor %}
         </tbody>
     </table>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure upload section and transcript table share the same max width
- style `.main-content` container for consistent layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867cd8fd0f8832180ee37bfe70e8a01