### PR TITLE
Fix download button layout

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -26,3 +26,14 @@ body.dark {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.result-cell {
+    display: flex;
+    align-items: center;
+    min-width: 450px;
+}
+
+.result-cell .result-snippet {
+    flex: 1;
+    min-width: 0;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -33,7 +33,7 @@
             <tr>
                 <td>{{ f.filename }}</td>
                 <td>{{ f.status }}</td>
-                <td>
+                <td class="result-cell">
                     {% if f.result %}
                         <span class="result-snippet">{{ f.result[:150] }}{% if f.result|length > 150 %}...{% endif %}</span>
                         <a class="btn btn-sm btn-secondary ms-2" href="/download/{{ f.id }}">Download</a>


### PR DESCRIPTION
## Summary
- align transcript snippet and download button in a dedicated flex container
- add style rules to keep column width consistent

## Testing
- `python -m py_compile app/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6867cff059cc832194a513c86af6655a