### PR TITLE
Add modal viewer for transcript and summary text

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -146,6 +146,19 @@ def download_text(file_id: int):
     return Response(text, media_type="text/plain", headers={"Content-Disposition": f"attachment; filename={filename}"})
 
 
+@app.get("/download_summary/{file_id}")
+def download_summary(file_id: int):
+    db = SessionLocal()
+    record = db.get(Transcript, file_id)
+    if not record or not record.summary:
+        db.close()
+        return RedirectResponse("/", status_code=302)
+    text = record.summary
+    filename = f"{record.filename}_summary.txt"
+    db.close()
+    return Response(text, media_type="text/plain", headers={"Content-Disposition": f"attachment; filename={filename}"})
+
+
 @app.post("/summarize/{file_id}")
 def summarize(file_id: int, background_tasks: BackgroundTasks, mode: str = Form("basic_summary")):
     db = SessionLocal()

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -37,3 +37,12 @@ body.dark {
     flex: 1;
     min-width: 0;
 }
+
+.clickable {
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.modal-pre {
+    white-space: pre-wrap;
+}

--- a/app/static/textmodal.js
+++ b/app/static/textmodal.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('textModal');
+  if (!modal) return;
+  const pre = modal.querySelector('.modal-pre');
+  const download = document.getElementById('modal-download');
+
+  modal.addEventListener('show.bs.modal', event => {
+    const trigger = event.relatedTarget;
+    if (!trigger) return;
+    const text = trigger.getAttribute('data-content') || '';
+    const dl = trigger.getAttribute('data-download') || '#';
+    pre.textContent = text;
+    download.href = dl;
+  });
+});

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,13 +35,12 @@
                 <td>{{ f.status }}</td>
                 <td class="result-cell">
                     {% if f.result %}
-                        <span class="result-snippet">{{ f.result[:150] }}{% if f.result|length > 150 %}...{% endif %}</span>
-                        <a class="btn btn-sm btn-secondary ms-2" href="/download/{{ f.id }}">Download</a>
+                        <span class="result-snippet clickable text-primary" role="button" data-bs-toggle="modal" data-bs-target="#textModal" data-content="{{ f.result|e }}" data-download="/download/{{ f.id }}">{{ f.result[:150] }}{% if f.result|length > 150 %}...{% endif %}</span>
                     {% endif %}
                 </td>
                 <td>
                     {% if f.summary %}
-                        <span class="result-snippet">{{ f.summary[:100] }}{% if f.summary|length > 100 %}...{% endif %}</span>
+                        <span class="result-snippet clickable text-primary" role="button" data-bs-toggle="modal" data-bs-target="#textModal" data-content="{{ f.summary|e }}" data-download="/download_summary/{{ f.id }}">{{ f.summary[:100] }}{% if f.summary|length > 100 %}...{% endif %}</span>
                     {% elif f.result %}
                         <form action="/summarize/{{ f.id }}" method="post" class="d-flex">
                             <select class="form-select form-select-sm me-2" name="mode">
@@ -60,5 +59,26 @@
         </tbody>
     </table>
     </div>
+
+    <div class="modal fade" id="textModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Full Text</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <pre class="modal-pre"></pre>
+                </div>
+                <div class="modal-footer">
+                    <a class="btn btn-primary" id="modal-download" href="#" download>Download</a>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/textmodal.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow viewing full transcript and summary from the table
- implement `/download_summary/<id>` endpoint
- style and script updates for modal popup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d13d8b208321a9d3146377433d61