### PR TITLE
Center index page and add Ollama options

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -30,6 +30,14 @@ def _ensure_schema() -> None:
             if "user_id" not in columns:
                 conn.execute(text("ALTER TABLE transcripts ADD COLUMN user_id INTEGER"))
 
+    if "users" in inspector.get_table_names():
+        columns = {c["name"] for c in inspector.get_columns("users")}
+        with engine.begin() as conn:
+            if "ollama_url" not in columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN ollama_url TEXT"))
+            if "ollama_model" not in columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN ollama_model TEXT"))
+
 class Transcript(Base):
     __tablename__ = "transcripts"
 
@@ -51,6 +59,8 @@ class User(Base):
     password_hash = Column(String, nullable=False)
     hf_token = Column(String, nullable=True)
     openai_token = Column(String, nullable=True)
+    ollama_url = Column(String, nullable=True)
+    ollama_model = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
 Base.metadata.create_all(bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -107,7 +107,13 @@ def settings_form(request: Request):
     return templates.TemplateResponse("settings.html", {"request": request, "user": user})
 
 @app.post("/settings", response_class=HTMLResponse)
-def settings_save(request: Request, hf_token: str = Form(""), openai_token: str = Form("")):
+def settings_save(
+    request: Request,
+    hf_token: str = Form(""),
+    openai_token: str = Form(""),
+    ollama_url: str = Form(""),
+    ollama_model: str = Form(""),
+):
     user = get_current_user(request)
     if not user:
         return RedirectResponse("/login", status_code=302)
@@ -115,6 +121,8 @@ def settings_save(request: Request, hf_token: str = Form(""), openai_token: str 
     db_user = db.get(User, user.id)
     db_user.hf_token = hf_token
     db_user.openai_token = openai_token
+    db_user.ollama_url = ollama_url
+    db_user.ollama_model = ollama_model
     db.commit()
     db.refresh(db_user)
     db.close()

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -20,8 +20,9 @@ body.dark {
     margin: 0 auto;
 }
 
+
 .result-snippet {
-    max-width: 400px;
+    max-width: 350px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -30,7 +31,7 @@ body.dark {
 .result-cell {
     display: flex;
     align-items: center;
-    min-width: 450px;
+    min-width: 350px;
 }
 
 .result-cell .result-snippet {

--- a/app/summarize.py
+++ b/app/summarize.py
@@ -3,11 +3,17 @@ import requests
 import openai
 
 
-def summarize(text: str, mode: str = "basic_summary", openai_api_key: str | None = None) -> str:
+def summarize(
+    text: str,
+    mode: str = "basic_summary",
+    openai_api_key: str | None = None,
+    ollama_url: str | None = None,
+    ollama_model: str | None = None,
+) -> str:
     engine = os.getenv("SUMMARIZATION_ENGINE", "openai")
     if engine == "openai":
         return summarize_openai(text, mode, openai_api_key)
-    return summarize_ollama(text, mode)
+    return summarize_ollama(text, mode, url=ollama_url, model=ollama_model)
 
 
 def summarize_openai(text: str, mode: str, api_key: str | None = None) -> str:
@@ -27,13 +33,19 @@ def summarize_openai(text: str, mode: str, api_key: str | None = None) -> str:
     return response.choices[0].message.content
 
 
-def summarize_ollama(text: str, mode: str) -> str:
+def summarize_ollama(
+    text: str,
+    mode: str,
+    *,
+    url: str | None = None,
+    model: str | None = None,
+) -> str:
     payload = {
-        "model": os.getenv("OLLAMA_MODEL", "mistral"),
+        "model": model or os.getenv("OLLAMA_MODEL", "mistral"),
         "prompt": f"Summarize the following transcript ({mode}):\n\n{text}",
         "stream": False,
     }
-    url = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
+    url = url or os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
     response = requests.post(url, json=payload, timeout=60)
     response.raise_for_status()
     data = response.json()

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -24,6 +24,7 @@
         <button class="btn btn-primary mt-2" type="submit">Upload & Transcribe</button>
     </form>
     <h2>Past Transcripts</h2>
+    <div class="table-responsive">
     <table class="table table-striped">
         <thead>
             <tr><th>File</th><th>Status</th><th>Result</th><th>Summary</th><th>Created</th></tr>
@@ -58,6 +59,7 @@
         {% endfor %}
         </tbody>
     </table>
+    </div>
     </div>
 
     <div class="modal fade" id="textModal" tabindex="-1" aria-hidden="true">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -18,6 +18,14 @@
             <label class="form-label">OpenAI Token</label>
             <input class="form-control" type="text" name="openai_token" value="{{ user.openai_token or '' }}">
         </div>
+        <div class="mb-3">
+            <label class="form-label">Ollama URL</label>
+            <input class="form-control" type="text" name="ollama_url" value="{{ user.ollama_url or '' }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Ollama Model</label>
+            <input class="form-control" type="text" name="ollama_model" value="{{ user.ollama_model or '' }}">
+        </div>
         <button class="btn btn-primary" type="submit">Save</button>
     </form>
     <p class="mt-3"><a href="/">Home</a></p>

--- a/app/transcribe.py
+++ b/app/transcribe.py
@@ -107,7 +107,15 @@ def summarize_record(record_id: int, mode: str) -> None:
         openai_token = (
             user.openai_token if user and user.openai_token else os.getenv("OPENAI_API_KEY")
         )
-        summary = summarize(text, mode, openai_api_key=openai_token)
+        ollama_url = user.ollama_url if user and user.ollama_url else os.getenv("OLLAMA_URL")
+        ollama_model = user.ollama_model if user and user.ollama_model else os.getenv("OLLAMA_MODEL")
+        summary = summarize(
+            text,
+            mode,
+            openai_api_key=openai_token,
+            ollama_url=ollama_url,
+            ollama_model=ollama_model,
+        )
         record.summary_status = "completed"
         record.summary = summary
         db.commit()


### PR DESCRIPTION
## Summary
- tweak snippet and cell widths so the main page fits on screen
- wrap transcript table in a responsive container
- store Ollama URL and model per user
- expose the new fields on the settings page
- pass user Ollama settings to summarization logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868e69f0f988321a6ab565fa889c4b5